### PR TITLE
Timber logger support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+
+        // Timber support
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
 
     configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
                     "android": "1.2.3",
                     "java"   : "1.4.3"
             ],
+            "timber"  : "5.0.0-SNAPSHOT",
             "truth"   : "1.0.1"
     ]
 

--- a/gradle/module-android-shared.gradle
+++ b/gradle/module-android-shared.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation("com.jakewharton.threetenabp:threetenabp:${versions.threeten.android}") {
         exclude group: 'org.threeten', module: 'threetenbp'
     }
+    implementation "com.jakewharton.timber:timber-android:${versions.timber}"
 
     // Kotlin dependencies for Android modules
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlin.coroutines}"

--- a/gradle/module-java.gradle
+++ b/gradle/module-java.gradle
@@ -40,6 +40,7 @@ jacocoTestReport.finalizedBy jacocoTestCoverageVerification
 dependencies {
 
     implementation "org.threeten:threetenbp:${versions.threeten.java}:no-tzdb"
+    implementation "com.jakewharton.timber:timber-jdk:${versions.timber}"
 
     testImplementation "org.threeten:threetenbp:${versions.threeten.java}"
 


### PR DESCRIPTION
Adds 5.0.0 version of Timber since this is the only one that supports Java modules